### PR TITLE
Reduce minimum RAM

### DIFF
--- a/app/assets/js/configmanager.js
+++ b/app/assets/js/configmanager.js
@@ -45,7 +45,7 @@ const firstLaunch = !fs.existsSync(configPath) && !fs.existsSync(configPathLEGAC
 
 exports.getAbsoluteMinRAM = function(){
     const mem = os.totalmem()
-    return mem >= 6000000000 ? 3 : 2
+    return mem >= 1073741824 : 1 ? 2
 }
 
 exports.getAbsoluteMaxRAM = function(){
@@ -56,7 +56,7 @@ exports.getAbsoluteMaxRAM = function(){
 
 function resolveMaxRAM(){
     const mem = os.totalmem()
-    return mem >= 8000000000 ? '4G' : (mem >= 6000000000 ? '3G' : '2G')
+    return mem >= 4294967296 ? '4G' : (mem >= 2147483648 ? '2G' : '1G')
 }
 
 function resolveMinRAM(){


### PR DESCRIPTION
Reduce minimum RAM from 6GB to 1GB. Also fixed some values in bytes to represent gigabytes more accurately when getting data with os.totalmem().